### PR TITLE
[omxplayer] Fix overdraw bug for QT EGL Backend

### DIFF
--- a/src/autoapp/Projection/OMXVideoOutput.cpp
+++ b/src/autoapp/Projection/OMXVideoOutput.cpp
@@ -114,8 +114,12 @@ bool OMXVideoOutput::setFullscreen()
     displayRegion.nSize = sizeof(OMX_CONFIG_DISPLAYREGIONTYPE);
     displayRegion.nVersion.nVersion = OMX_VERSION;
     displayRegion.nPortIndex = 90;
-    
-    displayRegion.set = static_cast<OMX_DISPLAYSETTYPE >(OMX_DISPLAY_SET_FULLSCREEN | OMX_DISPLAY_SET_NOASPECT);
+
+    //EGL surface needs the OMX layer to be 2
+    //Otherwise the Qt UI will draw on top of it
+    displayRegion.layer = 2;
+
+    displayRegion.set = static_cast<OMX_DISPLAYSETTYPE >(OMX_DISPLAY_SET_FULLSCREEN | OMX_DISPLAY_SET_NOASPECT | OMX_DISPLAY_SET_LAYER);
     displayRegion.fullscreen = OMX_TRUE;
     displayRegion.noaspect = OMX_TRUE;
     


### PR DESCRIPTION
On Qt5 EGL backend, the default draw layer for the UI is 1.
OMXplayer draws on layer 0, thus the interface never shows up.
This forces OMXplayer to draw on layer 2.

This allows the program to run on raspberry pi with EGLFS backend without needing X.