### PR TITLE
[audio] Avoid taking over phone audio path option

### DIFF
--- a/include/f1x/openauto/autoapp/Configuration/Configuration.hpp
+++ b/include/f1x/openauto/autoapp/Configuration/Configuration.hpp
@@ -43,6 +43,8 @@ public:
     HandednessOfTrafficType getHandednessOfTrafficType() const override;
     void showClock(bool value) override;
     bool showClock() const override;
+    void audioAvoidInterference(bool value) override;
+    bool audioAvoidInterference() const override;
 
     aasdk::proto::enums::VideoFPS::Enum getVideoFPS() const override;
     void setVideoFPS(aasdk::proto::enums::VideoFPS::Enum value) override;
@@ -70,6 +72,7 @@ private:
 
     HandednessOfTrafficType handednessOfTrafficType_;
     bool showClock_;
+    bool audioAvoidInterference_;
     aasdk::proto::enums::VideoFPS::Enum videoFPS_;
     aasdk::proto::enums::VideoResolution::Enum videoResolution_;
     size_t screenDPI_;
@@ -82,6 +85,7 @@ private:
     static const std::string cConfigFileName;
 
     static const std::string cGeneralShowClockKey;
+    static const std::string cAudioAvoidInterferenceKey;
     static const std::string cGeneralHandednessOfTrafficTypeKey;
 
     static const std::string cVideoFPSKey;

--- a/include/f1x/openauto/autoapp/Configuration/IConfiguration.hpp
+++ b/include/f1x/openauto/autoapp/Configuration/IConfiguration.hpp
@@ -50,6 +50,8 @@ public:
     virtual HandednessOfTrafficType getHandednessOfTrafficType() const = 0;
     virtual void showClock(bool value) = 0;
     virtual bool showClock() const = 0;
+    virtual void audioAvoidInterference(bool value) = 0;
+    virtual bool audioAvoidInterference() const = 0;
 
     virtual aasdk::proto::enums::VideoFPS::Enum getVideoFPS() const = 0;
     virtual void setVideoFPS(aasdk::proto::enums::VideoFPS::Enum value) = 0;

--- a/src/autoapp/Configuration/Configuration.cpp
+++ b/src/autoapp/Configuration/Configuration.cpp
@@ -33,6 +33,8 @@ const std::string Configuration::cConfigFileName = "openauto.ini";
 const std::string Configuration::cGeneralShowClockKey = "General.ShowClock";
 const std::string Configuration::cGeneralHandednessOfTrafficTypeKey = "General.HandednessOfTrafficType";
 
+const std::string Configuration::cAudioAvoidInterferenceKey = "Audio.AvoidInterference";
+
 const std::string Configuration::cVideoFPSKey = "Video.FPS";
 const std::string Configuration::cVideoResolutionKey = "Video.Resolution";
 const std::string Configuration::cVideoScreenDPIKey = "Video.ScreenDPI";
@@ -76,6 +78,8 @@ void Configuration::load()
                                                                                                 static_cast<uint32_t>(HandednessOfTrafficType::LEFT_HAND_DRIVE)));
         showClock_ = iniConfig.get<bool>(cGeneralShowClockKey, true);
 
+        audioAvoidInterference_ = iniConfig.get<bool>(cAudioAvoidInterferenceKey, false);
+
         videoFPS_ = static_cast<aasdk::proto::enums::VideoFPS::Enum>(iniConfig.get<uint32_t>(cVideoFPSKey,
                                                                                              aasdk::proto::enums::VideoFPS::_60));
 
@@ -105,6 +109,7 @@ void Configuration::reset()
 {
     handednessOfTrafficType_ = HandednessOfTrafficType::LEFT_HAND_DRIVE;
     showClock_ = true;
+    audioAvoidInterference_ = false;
     videoFPS_ = aasdk::proto::enums::VideoFPS::_60;
     videoResolution_ = aasdk::proto::enums::VideoResolution::_480p;
     screenDPI_ = 140;
@@ -120,6 +125,7 @@ void Configuration::save()
     boost::property_tree::ptree iniConfig;
     iniConfig.put<uint32_t>(cGeneralHandednessOfTrafficTypeKey, static_cast<uint32_t>(handednessOfTrafficType_));
     iniConfig.put<bool>(cGeneralShowClockKey, showClock_);
+    iniConfig.put<bool>(cAudioAvoidInterferenceKey, audioAvoidInterference_);
 
     iniConfig.put<uint32_t>(cVideoFPSKey, static_cast<uint32_t>(videoFPS_));
     iniConfig.put<uint32_t>(cVideoResolutionKey, static_cast<uint32_t>(videoResolution_));
@@ -152,6 +158,16 @@ void Configuration::showClock(bool value)
 bool Configuration::showClock() const
 {
     return showClock_;
+}
+
+void Configuration::audioAvoidInterference(bool value)
+{
+    audioAvoidInterference_ = value;
+}
+
+bool Configuration::audioAvoidInterference() const
+{
+    return audioAvoidInterference_;
 }
 
 aasdk::proto::enums::VideoFPS::Enum Configuration::getVideoFPS() const

--- a/src/autoapp/Projection/ServiceFactory.cpp
+++ b/src/autoapp/Projection/ServiceFactory.cpp
@@ -62,18 +62,22 @@ ServiceList ServiceFactory::create(aasdk::messenger::IMessenger::Pointer messeng
     IAudioInput::Pointer audioInput(new AudioInput(1, 16, 16000), std::bind(&QObject::deleteLater, std::placeholders::_1));
     serviceList.emplace_back(std::make_shared<AudioInputService>(ioService_, messenger, std::move(audioInput)));
 
-    IAudioOutput::Pointer mediaAudioOutput(new AudioOutput(2, 16, 48000), std::bind(&QObject::deleteLater, std::placeholders::_1));
-    serviceList.emplace_back(std::make_shared<MediaAudioService>(ioService_, messenger, std::move(mediaAudioOutput)));
-
-    IAudioOutput::Pointer speechAudioOutput(new AudioOutput(1, 16, 16000), std::bind(&QObject::deleteLater, std::placeholders::_1));
-    serviceList.emplace_back(std::make_shared<SpeechAudioService>(ioService_, messenger, std::move(speechAudioOutput)));
-
     IAudioOutput::Pointer systemAudioOutput(new AudioOutput(1, 16, 16000), std::bind(&QObject::deleteLater, std::placeholders::_1));
     serviceList.emplace_back(std::make_shared<SystemAudioService>(ioService_, messenger, std::move(systemAudioOutput)));
 
+    if (!configuration_->audioAvoidInterference()) {
+        IAudioOutput::Pointer mediaAudioOutput(new AudioOutput(2, 16, 48000), std::bind(&QObject::deleteLater, std::placeholders::_1));
+        serviceList.emplace_back(std::make_shared<MediaAudioService>(ioService_, messenger, std::move(mediaAudioOutput)));
+
+        IAudioOutput::Pointer speechAudioOutput(new AudioOutput(1, 16, 16000), std::bind(&QObject::deleteLater, std::placeholders::_1));
+        serviceList.emplace_back(std::make_shared<SpeechAudioService>(ioService_, messenger, std::move(speechAudioOutput)));
+    }
+
     serviceList.emplace_back(std::make_shared<SensorService>(ioService_, messenger));
     serviceList.emplace_back(this->createVideoService(messenger));
+
     serviceList.emplace_back(this->createBluetoothService(messenger));
+
     serviceList.emplace_back(this->createInputService(messenger));
 
     return serviceList;

--- a/src/autoapp/UI/SettingsWindow.cpp
+++ b/src/autoapp/UI/SettingsWindow.cpp
@@ -56,6 +56,7 @@ void SettingsWindow::onSave()
 {
     configuration_->setHandednessOfTrafficType(ui_->radioButtonLeftHandDrive->isChecked() ? configuration::HandednessOfTrafficType::LEFT_HAND_DRIVE : configuration::HandednessOfTrafficType::RIGHT_HAND_DRIVE);
     configuration_->showClock(ui_->checkBoxShowClock->isChecked());
+    configuration_->audioAvoidInterference(ui_->checkBoxAudioAvoidInterference->isChecked());
     configuration_->setVideoFPS(ui_->radioButton30FPS->isChecked() ? aasdk::proto::enums::VideoFPS::_30 : aasdk::proto::enums::VideoFPS::_60);
 
     if(ui_->radioButton480p->isChecked())
@@ -117,6 +118,7 @@ void SettingsWindow::load()
     ui_->radioButtonLeftHandDrive->setChecked(configuration_->getHandednessOfTrafficType() == configuration::HandednessOfTrafficType::LEFT_HAND_DRIVE);
     ui_->radioButtonRightHandDrive->setChecked(configuration_->getHandednessOfTrafficType() == configuration::HandednessOfTrafficType::RIGHT_HAND_DRIVE);
     ui_->checkBoxShowClock->setChecked(configuration_->showClock());
+    ui_->checkBoxAudioAvoidInterference->setChecked(configuration_->audioAvoidInterference());
 
     ui_->radioButton30FPS->setChecked(configuration_->getVideoFPS() == aasdk::proto::enums::VideoFPS::_30);
     ui_->radioButton60FPS->setChecked(configuration_->getVideoFPS() == aasdk::proto::enums::VideoFPS::_60);

--- a/src/autoapp/UI/settingswindow.ui
+++ b/src/autoapp/UI/settingswindow.ui
@@ -132,6 +132,19 @@ color: rgb(238, 238, 236);</string>
       <string>Show clock</string>
      </property>
     </widget>
+    <widget class="QCheckBox" name="checkBoxAudioAvoidInterference">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>160</y>
+       <width>601</width>
+       <height>23</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>[Experimental] Avoid taking over the phone's normal audio path</string>
+     </property>
+    </widget>
    </widget>
    <widget class="QWidget" name="tabVideo">
     <attribute name="title">


### PR DESCRIPTION
Normally the Android auto head unit would take over the phone's audio.
In many cases, this is undesirable because the existing Bluetooth
connection in the phone with the car stereo might do a better job of
handling audio/media control. This patch includes the option to make
the head unit to be as close to a screen-only device as possible.

When the option is enabled,
OpenAuto will not take over media and navigation voice channel.