### PR TITLE
Use specialized erase_begin to remove read data from sequential buffer

### DIFF
--- a/src/autoapp/Projection/SequentialBuffer.cpp
+++ b/src/autoapp/Projection/SequentialBuffer.cpp
@@ -55,7 +55,8 @@ qint64 SequentialBuffer::readData(char *data, qint64 maxlen)
 
     const auto len = std::min<size_t>(maxlen, data_.size());
     std::copy(data_.begin(), data_.begin() + len, data);
-    data_.erase(data_.begin(), data_.begin() + len);
+    data_.erase_begin(len);
+
     return len;
 }
 


### PR DESCRIPTION
Improved usage of circular_buffer (used methods with constant complexity).